### PR TITLE
Addition of /leagues related endpoints

### DIFF
--- a/src/iracing-client.ts
+++ b/src/iracing-client.ts
@@ -11,6 +11,7 @@ import {
   LapDataResponse,
   League,
   LeagueRoster,
+  LeagueSeasonSession,
   LeagueSeasonSessions,
   Member,
   MemberResponse,
@@ -261,13 +262,13 @@ class IracingClient {
     return signedData;
   }
 
-  public async getLeagueSeasonSesssions(leagueId: number,seasonId: number): Promise<LeagueSeasonSessions | null> {
+  public async getLeagueSeasonSesssions(leagueId: number,seasonId: number): Promise<LeagueSeasonSession | null> {
     await this.signIn();
     const res = await this.apiClient.get<SignedUrl>(
       `data/league/season_sessions?league_id=${leagueId}&season_id=${seasonId}`
     );
   
-    const signedData = await this.getResource<LeagueSeasonSessions>(res.data?.link);
+    const signedData = await this.getResource<LeagueSeasonSession>(res.data?.link);
   
     return signedData;
   }

--- a/src/iracing-client.ts
+++ b/src/iracing-client.ts
@@ -11,8 +11,7 @@ import {
   LapDataResponse,
   League,
   LeagueRoster,
-  LeagueSeasonSession,
-  LeagueSeasonSessions,
+  LeagueSeasonSessionsResponse,
   Member,
   MemberResponse,
   MemberStatHistory,
@@ -262,13 +261,13 @@ class IracingClient {
     return signedData;
   }
 
-  public async getLeagueSeasonSesssions(leagueId: number,seasonId: number): Promise<LeagueSeasonSession | null> {
+  public async getLeagueSeasonSesssions(leagueId: number,seasonId: number): Promise<LeagueSeasonSessionsResponse | null> {
     await this.signIn();
     const res = await this.apiClient.get<SignedUrl>(
       `data/league/season_sessions?league_id=${leagueId}&season_id=${seasonId}`
     );
   
-    const signedData = await this.getResource<LeagueSeasonSession>(res.data?.link);
+    const signedData = await this.getResource<LeagueSeasonSessionsResponse>(res.data?.link);
   
     return signedData;
   }

--- a/src/iracing-client.ts
+++ b/src/iracing-client.ts
@@ -9,9 +9,13 @@ import {
   CarDataResponse,
   EventLogResponse,
   LapDataResponse,
+  League,
+  LeagueRoster,
+  LeagueSeasonSessions,
   Member,
   MemberResponse,
   MemberStatHistory,
+  Season,
   SessionResult,
   SignedUrl,
   TrackAssetResponse,
@@ -222,6 +226,50 @@ class IracingClient {
       signedResponse.members.find((member) => member.cust_id === memberId) ??
       null
     );
+  }
+
+  public async getLeague(leagueId: number): Promise<League | null> {
+    await this.signIn();
+    const res = await this.apiClient.get<SignedUrl>(
+      `data/league/get?league_id=${leagueId}`
+    );
+
+    const signedData = await this.getResource<League>(res.data?.link);
+
+    return signedData;
+  }
+  
+  public async getLeagueSeasons(leagueId: number): Promise<Season | null> {
+    await this.signIn();
+    const res = await this.apiClient.get<SignedUrl>(
+      `data/league/seasons?league_id=${leagueId}`
+    );
+
+    const signedData = await this.getResource<Season>(res.data?.link);
+
+    return signedData;
+  }
+  
+  public async getLeagueRoster(leagueId: number): Promise<LeagueRoster | null> {
+    await this.signIn();
+    const res = await this.apiClient.get<SignedUrl>(
+      `data/league/roster?league_id=${leagueId}`
+    );
+  
+    const signedData = await this.getResource<LeagueRoster>(res.data?.data_url);
+  
+    return signedData;
+  }
+
+  public async getLeagueSeasonSesssions(leagueId: number,seasonId: number): Promise<LeagueSeasonSessions | null> {
+    await this.signIn();
+    const res = await this.apiClient.get<SignedUrl>(
+      `data/league/season_sessions?league_id=${leagueId}&season_id=${seasonId}`
+    );
+  
+    const signedData = await this.getResource<LeagueSeasonSessions>(res.data?.link);
+  
+    return signedData;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,25 @@ app.get('/results/lap_data', async (req, res) => {
   res.send(data);
 });
 
+app.get('/leagues/:leagueId', async (req, res) => {
+  const data = await client.getLeague(Number(req.params.leagueId));
+  res.send(data);
+});
+
+app.get('/leagues/:leagueId/seasons', async (req, res) => {
+  const data = await client.getLeagueSeasons(Number(req.params.leagueId));
+  res.send(data);
+});
+app.get('/leagues/:leagueId/seasons/:seasonId/sessions', async (req, res) => {
+  const data = await client.getLeagueSeasonSesssions(Number(req.params.leagueId),Number(req.params.seasonId));
+  res.send(data);
+});
+
+app.get('/leagues/:leagueId/roster', async (req, res) => {
+  const data = await client.getLeagueRoster(Number(req.params.leagueId));
+  res.send(data);
+});
+
 app.listen(3000, () => {
   console.log('Server running on port: ', 3000);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type AuthResponse = {
 };
 
 export type SignedUrl = {
+  data_url: string | undefined;
   link: string;
   expires: string | Date;
 };
@@ -528,4 +529,215 @@ export interface Helmet {
   color3: string;
   face_type: number;
   helmet_type: number;
+}
+
+export interface League {
+  league_id: number;
+  owner_id: number;
+  league_name: string;
+  created: string;
+  hidden: boolean;
+  message: string;
+  about: string;
+  url: string;
+  recruiting: boolean;
+  private_wall: boolean;
+  private_roster: boolean;
+  private_schedule: boolean;
+  private_results: boolean;
+  is_owner: boolean;
+  is_admin: boolean;
+  roster_count: boolean;
+  owner: {
+    cust_id: number;
+    display_name: string;
+    helmet: Helmet;
+  };
+  image: string;
+  large_logo: string;
+  tags: {
+    categorized: [];
+    not_categorized: [];
+  };
+  league_applications: [];
+  pending_requests: [];
+  is_member: boolean;
+  is_applicant: boolean;
+  is_invite: boolean;
+  is_ignored: boolean;
+  roster: LeagueRoster;
+}
+
+export interface LeagueRoster {
+  cust_id: number;
+  display_name: string;
+  helmet: Helmet;
+  owner: boolean;
+  admin: boolean;
+  league_mail_opt_out: boolean;
+  league_pm_opt_out: boolean;
+  leage_member_since: boolean;
+  car_number: string;
+  nick_name: string;
+}
+
+export interface SeasonsResponse {
+  subscribed: boolean;
+  seasons: Season[];
+  success: boolean;
+  retired: boolean;
+  league_id: number;
+}
+
+export interface Season {
+  league_id: number;
+  season_id: number;
+  points_system_id: number;
+  season_name: string;
+  active: boolean;
+  hidden: boolean;
+  num_drops: number;
+  no_drops_on_or_after_race_num: number;
+  points_cars: {
+    car_id: number;
+    car_name: string;
+  }[];
+  drivers_points_car_classes: SeasonCarClass[];
+  team_points_car_classes: SeasonCarClass[];
+  points_system_name: string;
+  points_system_desc: string;
+}
+
+export interface SeasonCarClass {
+  car_class_id: number;
+  name: string;
+  cars_in_class: {
+    car_id: number;
+    car_name: string;
+  }[];
+}
+
+export interface LeagueSeasonSessionsResponse {
+  sessions: LeagueSeasonSessions[];
+  success: boolean;
+  season_id: number;
+  league_id: number;
+}
+
+export interface LeagueSeasonSessions {
+  cars: {
+    car_id: number;
+    car_name: string;
+    car_class_id: number;
+    car_class_name: string;
+  }[];
+  driver_changes: boolean;
+  entry_count: number;
+  has_results: boolean;
+  heat_ses_info: HeatSessionInfo;
+  launch_at: string;
+  league_id: number;
+  league_season_id: number;
+  lone_qualify: boolean;
+  pace_car_class_id: number | null;
+  pace_car_id: number | null;
+  password_protected: boolean;
+  practice_length: number;
+  private_session_id: number;
+  qualify_laps: number;
+  qualify_length: number;
+  race_laps: number;
+  race_length: number;
+  session_id: number;
+  status: number;
+  subsession_id: number;
+  team_entry_count: number;
+  time_limit: number;
+  track: {
+    config_name: string;
+    track_id: number;
+    track_name: string;
+  }
+  track_state: TrackState;
+  weather: LeagueSeasonSessionWeather;
+  winner_id: number;
+  winner_name: string;
+}
+
+export interface HeatSessionInfo {
+  consolation_delta_max_field_size: number;
+  consolation_delta_session_laps: number;
+  consolation_delta_session_length_minutes: number;
+  consolation_first_max_field_size: number;
+  consolation_first_session_laps: number;
+  consolation_first_session_length_minutes: number;
+  consolation_num_position_to_invert: number;
+  consolation_num_to_consolation: number;
+  consolation_num_to_main: number;
+  consolation_run_always: boolean;
+  consolation_scores_champ_points: boolean;
+  created: string;
+  cust_id: number;
+  heat_caution_type: number;
+  heat_info_id: number;
+  heat_info_name: string;
+  heat_laps: number;
+  heat_length_minuts: number;
+  heat_max_field_size: number;
+  heat_num_for_each_to_main: number;
+  heat_num_position_to_invert: number;
+  heat_scores_champ_points: boolean;
+  heat_session_minutes_estimate: number;
+  hidden: boolean;
+  main_laps: number;
+  main_length_minutes: number;
+  main_max_field_size: number;
+  main_num_position_to_invert: number;
+  max_enterants: number;
+  open_practice: boolean;
+  pre_main_practice_length_minutes: number;
+  pre_qual_num_to_main: number;
+  pre_qual_practice_length_minutes: number;
+  qual_caution_type: number;
+  qual_laps: number;
+  qual_length_minutes: number;
+  qual_num_to_main: number;
+  qual_open_delay_seconds: number;
+  qual_scores_champ_points: boolean;
+  qual_scoring: number;
+  qual_style: number;
+  race_style: number;
+}
+
+export interface LeagueSeasonSessionWeather {
+  allow_fog: boolean;
+  fog: number;
+  precip_option: number;
+  rel_humidity: number;
+  skies: number;
+  temp_units: number;
+  temp_value: number;
+  track_water: number;
+  type: number;
+  version: number;
+  weather_summary: LeagueSeasonSessionWeatherSummary;
+  weather_val_initial: number;
+  weather_var_ongoing: number;
+  wind_dir: number;
+  wind_units: number;
+  wind_value: number;
+}
+
+export interface LeagueSeasonSessionWeatherSummary {
+  max_percip_rate: number;
+  max_percip_rate_desc: string;
+  percip_chance: number;
+  skies_high: number;
+  skies_low: number;
+  temp_high: number;
+  temp_low: number;
+  temp_units: number;
+  wind_high: number;
+  wind_low: number;
+  wind_units: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -618,13 +618,13 @@ export interface SeasonCarClass {
 }
 
 export interface LeagueSeasonSessionsResponse {
-  sessions: LeagueSeasonSessions[];
+  sessions: LeagueSeasonSession[];
   success: boolean;
   season_id: number;
   league_id: number;
 }
 
-export interface LeagueSeasonSessions {
+export interface LeagueSeasonSession {
   cars: {
     car_id: number;
     car_name: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces four new endpoints that pull data from iRacing:

- `getLeague`
- `getLeagueSeasons`
- `getLeagueSeasonSessions`
- `getLeagueRoster`

Additionally, several new interfaces have been added to improve type safety and data handling:

- Added an optional `data_url` property to the `signedUrl` interface.
- Added the following new interfaces:
  - `League`
  - `LeagueRoster`
  - `SeasonsResponse`
  - `Season`
  - `SeasonCarClass`
  - `LeagueSeasonSessionsResponse`
  - `LeagueSeasonsSession`
  - `HeatSessionInfo`
  - `LeagueSeasonSessionWeather`
  - `LeagueSeasonSessionWeatherSummary`

## Motivation and Context

These changes allow to pull league, season, and league related session data.

## How Has This Been Tested?

The changes have been tested in the following ways:

- Verified API responses using direct API calls.
- Checked integration with existing components to prevent breaking changes.

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have added tests for my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
